### PR TITLE
Implement list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,7 @@ bower.json
 
 # Ignore gem stuff
 pkg/
+
+# Ignore generated yard docs
+.yardoc/
+doc/

--- a/lib/accesscontrol.rb
+++ b/lib/accesscontrol.rb
@@ -2,13 +2,53 @@ require "accesscontrol/version"
 require "accesscontrol/records"
 require "accesscontrol/general"
 
+# AccessControl is the interface that hides the implementation
+# of the data layer. Tell AccessControl when to grant and revoke
+# permissions, ask it whether an actor has permission on a
+# record, ask it for a list of permitted records for the record
+# type, and ask it whether an actor has a general permission not
+# related to any certain record or record type.
 module AccessControl
   module_function
 
+  # AccessControl's tables are prefixed with access_control to
+  # prevent any naming conflicts with other tables in the database.
   def self.table_name_prefix
     "access_control_"
   end
-
+ 
+  # Check whether an actor has a given permission.
+  # @return [Boolean]
+  # @overload can?(actor, action_id, namespace)
+  #   Ask whether the actor has permission to perform action_id
+  #   in the given namespace. Multiple actions can have the same id
+  #   as long as their namespace is different. The namespace can be
+  #   any String. We recommend using namespace to group a class of
+  #   permissions, such as to group parts of a particular feature
+  #   in your application.
+  #
+  #   @param actor [ActiveRecord::Base] The actor we're checking for permission on.
+  #   @param action_id [Integer, Array<Integer>] The action or actions we're checking whether the actor has. If this is an array, then the check is ORed.
+  #   @param namespace [String] The namespace of the given action_id.
+  #   @return [Boolean] Returns true if actor has been granted the permission, false otherwise.
+  #
+  #   @example
+  #     # Can the user perform the action with id 3 for posts?
+  #     AccessControl.can?(user, 3, "posts")
+  #
+  # @overload can?(actor, action_id, object_type, object_id)
+  #   Ask whether the actor has permission to perform action_id
+  #   on a given record.
+  #
+  #   @param actor [ActiveRecord::Base] The actor we're checking for permission on.
+  #   @param action_id [Integer, Array<Integer>] The action or actions we're checking whether the actor has. If this is an array, then the check is ORed.
+  #   @param object_type [ActiveRecord::Base] The ActiveRecord model which we're checking for permission on.
+  #   @param object_id [Integer] The id of the ActiveRecord object which we're checking for permission on.
+  #   @return [Boolean] Returns true if actor has been granted the permission on the specified record, false otherwise.
+  #
+  #   @example
+  #     # Can the user perform the action with id 5 for the Post with id 7?
+  #     AccessControl.can?(user, 5, Post, 7)
   def can?(actor, action_id, object_type, object_id = nil)
     if object_id.nil?
       General.can?(actor, action_id, object_type)
@@ -17,6 +57,21 @@ module AccessControl
     end
   end
 
+  # Returns an ActiveRecord::Relation of object_type containing the
+  # records on which the actor has permission to perform action_id.
+  #
+  # @param actor [ActiveRecord::Base] The actor we're loading records for.
+  # @param action_id [Integer] The action we're checking whether the actor has.
+  # @param object_type [ActiveRecord::Base] The ActiveRecord model to be loaded.
+  # @return [ActiveRecord::Relation]
+  #
+  # @example
+  #   # Give me the list of Posts on which the user has permission to perform action_id 3
+  #   AccessControl.list(user, 3, Post)
+  # @example
+  #   # You can chain ActiveRecord query methods to further filter the results
+  #   # Give me the list of Posts on which the user has permission to perform action_id 3, and which have the title "Untitled", but limit to 5 results
+  #   AccessControl.list(user, 3, Post).where(title: "Untitled").limit(5)
   def list(actor, action_id, object_type)
     Records.list(actor, action_id, object_type)
   end

--- a/lib/accesscontrol.rb
+++ b/lib/accesscontrol.rb
@@ -1,5 +1,6 @@
 require "accesscontrol/version"
-require "accesscontrol/models/permitted_action"
+require "accesscontrol/records"
+require "accesscontrol/general"
 
 module AccessControl
   module_function
@@ -10,18 +11,9 @@ module AccessControl
 
   def can?(actor, action_id, object_type, object_id = nil)
     if object_id.nil?
-      PermittedAction.where(
-        actor: actor,
-        action: action_id,
-        object_type: String(object_type),
-      ).exists?
+      General.can?(actor, action_id, object_type)
     else
-      PermittedActionOnObject.where(
-        actor: actor,
-        action: action_id,
-        object_type: String(object_type),
-        object_id: object_id
-      ).exists?
+      Records.can?(actor, action_id, object_type, object_id)
     end
   end
 

--- a/lib/accesscontrol.rb
+++ b/lib/accesscontrol.rb
@@ -18,6 +18,7 @@ module AccessControl
   end
 
   def list(actor, action_id, object_type)
+    Records.list(actor, action_id, object_type)
   end
 
   def grant(actor, action_id, object_type, object_id = nil)

--- a/lib/accesscontrol/general.rb
+++ b/lib/accesscontrol/general.rb
@@ -1,7 +1,24 @@
 module AccessControl
+
+  # Permission checks not directly related to records happen here.
   module General
     module_function
 
+    # Ask whether the actor has permission to perform action_id
+    # in the given namespace. Multiple actions can have the same id
+    # as long as their namespace is different. The namespace can be
+    # any String. We recommend using namespace to group a class of
+    # permissions, such as to group parts of a particular feature
+    # in your application.
+    #
+    # @param actor [ActiveRecord::Base] The actor we're checking for permission on.
+    # @param action_id [Integer, Array<Integer>] The action or actions we're checking whether the actor has. If this is an array, then the check is ORed.
+    # @param namespace [String] The namespace of the given action_id.
+    # @return [Boolean] Returns true if actor has been granted the permission, false otherwise.
+    #
+    # @example
+    #   # Can the user perform the action with id 3 for posts?
+    #   AccessControl::General.can?(user, 3, "posts")
     def can?(actor, action_id, object_type)
       PermittedAction.where(
         actor: actor,

--- a/lib/accesscontrol/general.rb
+++ b/lib/accesscontrol/general.rb
@@ -1,0 +1,13 @@
+module AccessControl
+  module General
+    module_function
+
+    def can?(actor, action_id, object_type)
+      PermittedAction.where(
+        actor: actor,
+        action: action_id,
+        object_type: String(object_type),
+      ).exists?
+    end
+  end
+end

--- a/lib/accesscontrol/records.rb
+++ b/lib/accesscontrol/records.rb
@@ -10,5 +10,17 @@ module AccessControl
         object_id: object_id
       ).exists?
     end
+
+    def list(actor, action_id, object_type)
+      action_id = Integer(action_id)
+
+      object_type.where(id: 
+        PermittedActionOnObject.where(
+          actor: actor,
+          action: action_id,
+          object_type: String(object_type)
+        ).select(:object_id)
+      )
+    end
   end
 end

--- a/lib/accesscontrol/records.rb
+++ b/lib/accesscontrol/records.rb
@@ -1,7 +1,21 @@
 module AccessControl
+
+  # Permission checks directly related to specific ActiveRecord records happen here.
   module Records
     module_function
 
+    # Ask whether the actor has permission to perform action_id
+    # on a given record.
+    #
+    # @param actor [ActiveRecord::Base] The actor we're checking for permission on.
+    # @param action_id [Integer, Array<Integer>] The action or actions we're checking whether the actor has. If this is an array, then the check is ORed.
+    # @param object_type [ActiveRecord::Base] The ActiveRecord model which we're checking for permission on.
+    # @param object_id [Integer] The id of the ActiveRecord object which we're checking for permission on.
+    # @return [Boolean] Returns true if actor has been granted the permission on the specified record, false otherwise.
+    #
+    # @example
+    #   # Can the user perform the action with id 5 for the Post with id 7?
+    #   AccessControl::Records.can?(user, 5, Post, 7)
     def can?(actor, action_id, object_type, object_id)
       PermittedActionOnObject.where(
         actor: actor,
@@ -11,6 +25,21 @@ module AccessControl
       ).exists?
     end
 
+    # Returns an ActiveRecord::Relation of object_type containing the
+    # records on which the actor has permission to perform action_id.
+    #
+    # @param actor [ActiveRecord::Base] The actor we're loading records for.
+    # @param action_id [Integer] The action we're checking whether the actor has.
+    # @param object_type [ActiveRecord::Base] The ActiveRecord model to be loaded.
+    # @return [ActiveRecord::Relation]
+    #
+    # @example
+    #   # Give me the list of Posts on which the user has permission to perform action_id 3
+    #   AccessControl.list(user, 3, Post)
+    # @example
+    #   # You can chain ActiveRecord query methods to further filter the results
+    #   # Give me the list of Posts on which the user has permission to perform action_id 3, and which have the title "Untitled", but limit to 5 results
+    #   AccessControl::Records.list(user, 3, Post).where(title: "Untitled").limit(5)
     def list(actor, action_id, object_type)
       action_id = Integer(action_id)
 

--- a/lib/accesscontrol/records.rb
+++ b/lib/accesscontrol/records.rb
@@ -1,0 +1,14 @@
+module AccessControl
+  module Records
+    module_function
+
+    def can?(actor, action_id, object_type, object_id)
+      PermittedActionOnObject.where(
+        actor: actor,
+        action: action_id,
+        object_type: String(object_type),
+        object_id: object_id
+      ).exists?
+    end
+  end
+end

--- a/test/permitted_general_action_test.rb
+++ b/test/permitted_general_action_test.rb
@@ -1,0 +1,22 @@
+require 'test_helper'
+
+describe AccessControl do
+  it 'returns false when actor lacks access' do
+    actor = User.create!
+
+    AccessControl.can?(actor, 1, Post).must_equal false
+  end
+
+  it 'retuns true when the actor has access' do
+    actor = User.create!
+
+    AccessControl::PermittedAction.create!(
+      id: SecureRandom.uuid,
+      actor: actor,
+      action: 1,
+      object_type: Post
+    )
+
+    AccessControl.can?(actor, 1, Post).must_equal true
+  end
+end

--- a/test/permitted_objects_list_test.rb
+++ b/test/permitted_objects_list_test.rb
@@ -1,0 +1,51 @@
+require 'test_helper'
+
+describe AccessControl do
+
+  it 'returns an ActiveRecord::Relation of the object class' do
+    return_value = AccessControl.list(User.create!, 1, Post)
+
+    return_value.class.ancestors.must_include ActiveRecord::Relation
+    return_value.model.must_equal Post
+  end
+
+  it 'returns a list of records the actor has access to with the given action' do
+    actor1 = User.create!
+    actor2 = User.create!
+    post1 = Post.create!
+    post2 = Post.create!
+    post3 = Post.create!
+
+    [post1, post3].each do |post|
+      AccessControl::PermittedActionOnObject.create!(
+        id: SecureRandom.uuid,
+        actor: actor1,
+        action: 1,
+        object_type: Post,
+        object_id: post.id
+      )
+    end
+
+    [post2, post3].each do |post|
+      AccessControl::PermittedActionOnObject.create!(
+        id: SecureRandom.uuid,
+        actor: actor2,
+        action: 2,
+        object_type: Post,
+        object_id: post.id
+      )
+    end
+
+    AccessControl.list(actor1, 1, Post).order(:id).must_equal [post1, post3]
+    AccessControl.list(actor1, 2, Post).order(:id).must_equal []
+    AccessControl.list(actor1, 3, Post).order(:id).must_equal []
+
+    AccessControl.list(actor2, 1, Post).order(:id).must_equal []
+    AccessControl.list(actor2, 2, Post).order(:id).must_equal [post2, post3]
+    AccessControl.list(actor2, 3, Post).order(:id).must_equal []
+  end
+
+  it 'does not accept an array of actions' do
+    -> { AccessControl.list(User.create!, [1, 2, 3], Post) }.must_raise TypeError
+  end
+end

--- a/test/permittted_records_test.rb
+++ b/test/permittted_records_test.rb
@@ -1,25 +1,6 @@
 require 'test_helper'
 
 describe AccessControl do
-  it 'returns false when actor lacks access' do
-    actor = User.create!
-
-    AccessControl.can?(actor, 1, Post).must_equal false
-  end
-
-  it 'retuns true when the actor has access' do
-    actor = User.create!
-
-    AccessControl::PermittedAction.create!(
-      id: SecureRandom.uuid,
-      actor: actor,
-      action: 1,
-      object_type: Post
-    )
-
-    AccessControl.can?(actor, 1, Post).must_equal true
-  end
-
   it 'returns false when actor lacks access to an object' do
     actor = User.create!
     post = Post.create!
@@ -60,5 +41,4 @@ describe AccessControl do
     AccessControl.can?(actor, 1, Post, post.id).must_equal true
     AccessControl.can?(actor, [3,2], Post, post.id).must_equal false
   end
-
 end


### PR DESCRIPTION
This PR implements the `list` method. I also did a couple other things:

### A minor refactor to move similar functionality into their own modules

`AccessControl::General` deals with permissions not directly related to specific records. Things like create operations, feature flags, etc.

`AccessControl::Records` deals with permissions directly related to specific records. `list` is defined here.

And I also split the test file into logical test files.

### Yard Documentation

Run the following and visit `localhost:8808` to see the documentation in action:

```
gem install yard
yard server
```