### PR TITLE
refer to namespace rather than object_type and object_id

### DIFF
--- a/lib/accessly/permission/grant.rb
+++ b/lib/accessly/permission/grant.rb
@@ -38,8 +38,8 @@ module Accessly
       #   A grant is universally unique and is enforced at the database level.
       #
       #   @param action_id [Integer] The action to grant for the object
-      #   @param namespace [Class] The Class that receives a permission grant.
-      #   @param namespace_id [Integer] The id of the namespaced object which receives a permission grant
+      #   @param namespace [ActiveRecord::Base] The ActiveRecord model that receives a permission grant.
+      #   @param namespace_id [Integer] The id of the ActiveRecord object which receives a permission grant
       #   @raise [Accessly::GrantError] if the operation does not succeed
       #   @return [nil] Returns nil if successful
       #

--- a/lib/accessly/permission/grant.rb
+++ b/lib/accessly/permission/grant.rb
@@ -18,12 +18,12 @@ module Accessly
 
       # Grant a permission to an actor.
       # @return [nil]
-      # @overload grant!(action_id, object_type)
-      #   Allow permission on a general action in the given namespace represented by object_type.
+      # @overload grant!(action_id, namespace)
+      #   Allow permission on a general action in the given namespace.
       #   A grant is universally unique and is enforced at the database level.
       #
       #   @param action_id [Integer] The action to grant for the object
-      #   @param object_type [String] The namespace of the given action_id.
+      #   @param namespace [String] The namespace of the given action_id.
       #   @raise [Accessly::GrantError] if the operation does not succeed
       #   @return [nil] Returns nil if successful
       #
@@ -33,13 +33,13 @@ module Accessly
       #     # Allow the user access to posts for action id 3 on a segment
       #     Accessly::Permission::Grant.new(user).on_segment(1).grant!(3, "posts")
       #
-      # @overload grant!(action_id, object_type, object_id)
-      #   Allow permission on an ActiveRecord object.
+      # @overload grant!(action_id, namespace, namespace_id)
+      #   Allow permission on a namespaced object.
       #   A grant is universally unique and is enforced at the database level.
       #
       #   @param action_id [Integer] The action to grant for the object
-      #   @param object_type [ActiveRecord::Base] The ActiveRecord model that receives a permission grant.
-      #   @param object_id [Integer] The id of the ActiveRecord object which receives a permission grant
+      #   @param namespace [Class] The Class that receives a permission grant.
+      #   @param namespace_id [Integer] The id of the namespaced object which receives a permission grant
       #   @raise [Accessly::GrantError] if the operation does not succeed
       #   @return [nil] Returns nil if successful
       #
@@ -48,45 +48,45 @@ module Accessly
       #     Accessly::Permission::Grant.new(user).grant!(3, Post, 7)
       #     # Allow the user access to Post 7 for action id 3 on a segment
       #     Accessly::Permission::Grant.new(user).on_segment(1).grant!(3, Post, 7)
-      def grant!(action_id, object_type, object_id = nil)
-        if object_id.nil?
-          general_action_grant(action_id, object_type)
+      def grant!(action_id, namespace, namespace_id = nil)
+        if namespace_id.nil?
+          general_action_grant(action_id, namespace)
         else
-          object_action_grant(action_id, object_type, object_id)
+          object_action_grant(action_id, namespace, namespace_id)
         end
       end
 
       private
 
-      def general_action_grant(action_id, object_type)
+      def general_action_grant(action_id, namespace)
         Accessly::PermittedAction.create!(
           id: SecureRandom.uuid,
           segment_id: @segment_id,
           actor: @actor,
           action: action_id,
-          object_type: String(object_type)
+          namespace: String(namespace)
         )
         nil
       rescue ActiveRecord::RecordNotUnique
         nil
       rescue => e
-        raise Accessly::GrantError.new("Could not grant action #{action_id} on object #{object_type} for actor #{@actor} because #{e}")
+        raise Accessly::GrantError.new("Could not grant action #{action_id} on namespace #{namespace} for actor #{@actor} because #{e}")
       end
 
-      def object_action_grant(action_id, object_type, object_id)
+      def object_action_grant(action_id, namespace, namespace_id)
         Accessly::PermittedActionOnObject.create!(
           id: SecureRandom.uuid,
           segment_id: @segment_id,
           actor: @actor,
           action: action_id,
-          object_type: String(object_type),
-          object_id: object_id
+          namespace: String(namespace),
+          namespace_id: namespace_id
         )
         nil
       rescue ActiveRecord::RecordNotUnique
         nil
       rescue => e
-        raise Accessly::GrantError.new("Could not grant action #{action_id} on object #{object_type} with id #{object_id} for actor #{@actor} because #{e}")
+        raise Accessly::GrantError.new("Could not grant action #{action_id} on namespace #{namespace} with id #{namespace_id} for actor #{@actor} because #{e}")
       end
     end
   end

--- a/lib/accessly/permission/revoke.rb
+++ b/lib/accessly/permission/revoke.rb
@@ -18,11 +18,11 @@ module Accessly
 
       # Revoke a permission for an actor.
       # @return [nil]
-      # @overload revoke!(action_id, object_type)
-      #   Revoke permission on a general action in the given namespace represented by object_type.
+      # @overload revoke!(action_id, namespace)
+      #   Revoke permission on a general action in the given namespace.
       #
       #   @param action_id [Integer] The action to revoke
-      #   @param object_type [String] The namespace of the given action_id.
+      #   @param namespace [String] The namespace of the given action_id.
       #   @raise [Accessly::RevokeError] if the operation does not succeed
       #   @return [nil] Returns nil if successful
       #
@@ -32,12 +32,12 @@ module Accessly
       #     # Remove user access to posts for action id 3 on a segment
       #     Accessly::Permission::Revoke.new(user).on_segment(1).revoke!(3, Post)
       #
-      # @overload revoke!(action_id, object_type, object_id)
+      # @overload revoke!(action_id, namespace, namespace_id)
       #   Revoke permission on an ActiveRecord object.
       #
       #   @param action_id [Integer] The action to revoke
-      #   @param object_type [ActiveRecord::Base] The ActiveRecord model that removes a permission.
-      #   @param object_id [Integer] The id of the ActiveRecord object that removes a permission
+      #   @param namespace [Class] The namespace to remove a permission.
+      #   @param namespace_id [Integer] The id of the namespaced object that removes a permission
       #   @raise [Accessly::RevokeError] if the operation does not succeed
       #   @return [nil] Returns nil if successful
       #
@@ -46,39 +46,39 @@ module Accessly
       #     Accessly::Permission::Revoke.new(user).revoke!(3, Post, 7)
       #     # Remove user access to Post 7 for action id 3 on a segment
       #     Accessly::Permission::Revoke.new(user).on_segment(1).revoke!(3, Post, 7)
-      def revoke!(action_id, object_type, object_id = nil)
-        if object_id.nil?
-          general_action_revoke(action_id, object_type)
+      def revoke!(action_id, namespace, namespace_id = nil)
+        if namespace_id.nil?
+          general_action_revoke(action_id, namespace)
         else
-          object_action_revoke(action_id, object_type, object_id)
+          object_action_revoke(action_id, namespace, namespace_id)
         end
       end
 
       private
 
-      def general_action_revoke(action_id, object_type)
+      def general_action_revoke(action_id, namespace)
         Accessly::PermittedAction.where(
           segment_id: @segment_id,
           actor: @actor,
           action: action_id,
-          object_type: String(object_type)
+          namespace: String(namespace)
         ).delete_all
         nil
       rescue => e
-        raise Accessly::RevokeError.new("Could not revoke action #{action_id} on object #{object_type} for actor #{@actor} because #{e}")
+        raise Accessly::RevokeError.new("Could not revoke action #{action_id} on object #{namespace} for actor #{@actor} because #{e}")
       end
 
-      def object_action_revoke(action_id, object_type, object_id)
+      def object_action_revoke(action_id, namespace, namespace_id)
         Accessly::PermittedActionOnObject.where(
           segment_id: @segment_id,
           actor: @actor,
           action: action_id,
-          object_type: String(object_type),
-          object_id: object_id
+          namespace: String(namespace),
+          namespace_id: namespace_id
         ).delete_all
         nil
       rescue => e
-        raise Accessly::RevokeError.new("Could not revoke #{action_id} on object #{object_type} with id #{object_id} for actor #{@actor} because #{e}")
+        raise Accessly::RevokeError.new("Could not revoke #{action_id} on namespace #{namespace} with id #{namespace_id} for actor #{@actor} because #{e}")
       end
     end
   end

--- a/lib/accessly/permission/revoke.rb
+++ b/lib/accessly/permission/revoke.rb
@@ -33,11 +33,11 @@ module Accessly
       #     Accessly::Permission::Revoke.new(user).on_segment(1).revoke!(3, Post)
       #
       # @overload revoke!(action_id, namespace, namespace_id)
-      #   Revoke permission on an ActiveRecord object.
+      #   Revoke permission on a namespaced object.
       #
       #   @param action_id [Integer] The action to revoke
-      #   @param namespace [Class] The namespace to remove a permission.
-      #   @param namespace_id [Integer] The id of the namespaced object that removes a permission
+      #   @param namespace [ActiveRecord::Base] The ActiveRecord model to remove a permission.
+      #   @param namespace_id [Integer] The id of the ActiveRecord object that removes a permission
       #   @raise [Accessly::RevokeError] if the operation does not succeed
       #   @return [nil] Returns nil if successful
       #

--- a/lib/accessly/permitted_actions/on_object_query.rb
+++ b/lib/accessly/permitted_actions/on_object_query.rb
@@ -11,8 +11,8 @@ module Accessly
       # Lookups are cached in the object to prevent redundant database calls.
       #
       # @param action_id [Integer, Array<Integer>] The action or actions we're checking whether the actor has. If this is an array, then the check is ORed.
-      # @param object_type [ActiveRecord::Base] The ActiveRecord model which we're checking for permission on.
-      # @param object_id [Integer] The id of the ActiveRecord object which we're checking for permission on.
+      # @param namespace [Class] The namespace which we're checking for permission on.
+      # @param namespace_id [Integer] The id of the namespaced object which we're checking for permission on.
       # @return [Boolean] Returns true if actor has been granted the permission on the specified record, false otherwise.
       #
       # @example
@@ -20,14 +20,14 @@ module Accessly
       #   Accessly::Query.new(user).can?(5, Post, 7)
       #   # Can the user perform the action with id 5 for the Post with id 7 on segment 1?
       #   Accessly::Query.new(user).on_segment(1).can?(5, Post, 7)
-      def can?(action_id, object_type, object_id)
-        find_or_set_value(action_id, object_type, object_id) do
+      def can?(action_id, namespace, namespace_id)
+        find_or_set_value(action_id, namespace, namespace_id) do
           Accessly::QueryBuilder.with_actors(Accessly::PermittedActionOnObject, @actors)
             .where(
               segment_id: @segment_id,
               action: action_id,
-              object_type: String(object_type),
-              object_id: object_id
+              namespace: String(namespace),
+              namespace_id: namespace_id
             ).exists?
         end
       end
@@ -54,8 +54,8 @@ module Accessly
           .where(
             segment_id: @segment_id,
             action: Integer(action_id),
-            object_type: String(namespace),
-          ).select(:object_id)
+            namespace: String(namespace),
+          ).select(:namespace_id)
       end
     end
   end

--- a/lib/accessly/permitted_actions/on_object_query.rb
+++ b/lib/accessly/permitted_actions/on_object_query.rb
@@ -11,8 +11,8 @@ module Accessly
       # Lookups are cached in the object to prevent redundant database calls.
       #
       # @param action_id [Integer, Array<Integer>] The action or actions we're checking whether the actor has. If this is an array, then the check is ORed.
-      # @param namespace [Class] The namespace which we're checking for permission on.
-      # @param namespace_id [Integer] The id of the namespaced object which we're checking for permission on.
+      # @param namespace [ActiveRecord::Base] The ActiveRecord model for permission check.
+      # @param namespace_id [Integer] The id of the ActiveRecord object for permission check.
       # @return [Boolean] Returns true if actor has been granted the permission on the specified record, false otherwise.
       #
       # @example

--- a/lib/accessly/permitted_actions/query.rb
+++ b/lib/accessly/permitted_actions/query.rb
@@ -18,7 +18,7 @@ module Accessly
       # Lookups are cached in the object to prevent redundant database calls.
       #
       # @param action_id [Integer, Array<Integer>] The action or actions we're checking whether the actor has. If this is an array, then the check is ORed.
-      # @param object_type [String] The namespace of the given action_id.
+      # @param namespace [String] The namespace of the given action_id.
       # @return [Boolean] Returns true if actor has been granted the permission, false otherwise.
       #
       # @example
@@ -26,13 +26,13 @@ module Accessly
       #   Accessly::Query.new(user).can?(3, Post)
       #   # Can the user perform the action with id 3 for posts on segment 1?
       #   Accessly::Query.new(user).on_segment(1).can?(3, Post)
-      def can?(action_id, object_type)
-        find_or_set_value(action_id, object_type) do
+      def can?(action_id, namespace)
+        find_or_set_value(action_id, namespace) do
           Accessly::QueryBuilder.with_actors(Accessly::PermittedAction, @actors)
             .where(
               segment_id: @segment_id,
               action: action_id,
-              object_type: String(object_type),
+              namespace: String(namespace),
             ).exists?
         end
       end

--- a/lib/accessly/query.rb
+++ b/lib/accessly/query.rb
@@ -52,13 +52,13 @@ module Accessly
     #     # Can the sets of actors on segment 1 perform the action with id 5 for Posts
     #     Accessly::Query.new(User => user.id, Group => [1,2]).on_segment(1).can?(5, Post)
     #
-    # @overload can?(action_id, object_type, object_id)
+    # @overload can?(action_id, namespace, namespace_id)
     #   Ask whether the actor has permission to perform action_id
     #   on a given record.
     #
     #   @param action_id [Integer, Array<Integer>] The action or actions we're checking whether the actor has. If this is an array, then the check is ORed.
-    #   @param object_type [ActiveRecord::Base] The ActiveRecord model which we're checking for permission on.
-    #   @param object_id [Integer] The id of the ActiveRecord object which we're checking for permission on.
+    #   @param namespace [Class] The namespace which we're checking for permissions.
+    #   @param namespace_id [Integer] The id of the namespace object which we're checking for permission on.
     #   @return [Boolean] Returns true if actor has been granted the permission on the specified record, false otherwise.
     #
     #   @example
@@ -70,11 +70,11 @@ module Accessly
     #     Accessly::Query.new(user).on_segment(1).can?(5, Post, 7)
     #     # Can the sets of actors on segment 1 perform the action with id 5 for the Post with id 7?
     #     Accessly::Query.new(User => user.id, Group => [1,2]).on_segment(1).can?(5, Post, 7)
-    def can?(action_id, object_type, object_id = nil)
-      if object_id.nil?
-        permitted_action_query.can?(action_id, object_type)
+    def can?(action_id, namespace, namespace_id = nil)
+      if namespace_id.nil?
+        permitted_action_query.can?(action_id, namespace)
       else
-        permitted_action_on_object_query.can?(action_id, object_type, object_id)
+        permitted_action_on_object_query.can?(action_id, namespace, namespace_id)
       end
     end
 

--- a/lib/accessly/query.rb
+++ b/lib/accessly/query.rb
@@ -57,8 +57,8 @@ module Accessly
     #   on a given record.
     #
     #   @param action_id [Integer, Array<Integer>] The action or actions we're checking whether the actor has. If this is an array, then the check is ORed.
-    #   @param namespace [Class] The namespace which we're checking for permissions.
-    #   @param namespace_id [Integer] The id of the namespace object which we're checking for permission on.
+    #   @param namespace [ActiveRecord::Base] The ActiveRecord model for permission check.
+    #   @param namespace_id [Integer] The id of the ActiveRecord object for permission check.
     #   @return [Boolean] Returns true if actor has been granted the permission on the specified record, false otherwise.
     #
     #   @example

--- a/lib/generators/accessly/install/templates/db/migrate/create_permitted_action_on_objects.rb
+++ b/lib/generators/accessly/install/templates/db/migrate/create_permitted_action_on_objects.rb
@@ -5,11 +5,11 @@ class CreatePermittedActionOnObjects < ActiveRecord::Migration<%= migration_vers
       t.column :action, :integer, null: false
       t.column :actor_id, :integer, null: false
       t.column :actor_type, :string, null: false
-      t.column :object_type, :string, null: false
-      t.column :object_id, :integer, null: false
+      t.column :namespace, :string, null: false
+      t.column :namespace_id, :integer, null: false
     end
 
-    add_index(:accessly_permitted_action_on_objects, [:segment_id, :actor_type, :actor_id, :object_type, :object_id, :action], unique: true, name: "acessly_paoo_uniq_table_idx")
-    add_index(:accessly_permitted_action_on_objects, [:segment_id, :object_type, :object_id, :action], name: "acessly_paoo_on_object_idx")
+    add_index(:accessly_permitted_action_on_objects, [:segment_id, :actor_type, :actor_id, :namespace, :namespace_id, :action], unique: true, name: "acessly_paoo_uniq_table_idx")
+    add_index(:accessly_permitted_action_on_objects, [:segment_id, :namespace, :namespace_id, :action], name: "acessly_paoo_namespace_idx")
   end
 end

--- a/lib/generators/accessly/install/templates/db/migrate/create_permitted_actions.rb
+++ b/lib/generators/accessly/install/templates/db/migrate/create_permitted_actions.rb
@@ -5,9 +5,9 @@ class CreatePermittedActions < ActiveRecord::Migration<%= migration_version %>
       t.column :action, :integer, null: false
       t.column :actor_id, :integer, null: false
       t.column :actor_type, :string, null: false
-      t.column :object_type, :string, null: false
+      t.column :namespace, :string, null: false
     end
 
-    add_index(:accessly_permitted_actions, [:segment_id, :actor_type, :actor_id, :object_type, :action], unique: true, name: "acessly_pa_uniq_table_idx")
+    add_index(:accessly_permitted_actions, [:segment_id, :actor_type, :actor_id, :namespace, :action], unique: true, name: "acessly_pa_uniq_table_idx")
   end
 end

--- a/test/cached_results_test.rb
+++ b/test/cached_results_test.rb
@@ -10,7 +10,7 @@ describe Accessly do
       id: SecureRandom.uuid,
       actor: actor,
       action: 1,
-      object_type: Post
+      namespace: Post
     )
 
     query.can?(1, Post).must_equal false
@@ -25,8 +25,8 @@ describe Accessly do
       id: SecureRandom.uuid,
       actor: actor,
       action: 9,
-      object_type: Post,
-      object_id: post.id
+      namespace: Post,
+      namespace_id: post.id
     )
 
     query = Accessly::Query.new(actor)

--- a/test/list_records_test.rb
+++ b/test/list_records_test.rb
@@ -15,32 +15,32 @@ describe Accessly do
       id: SecureRandom.uuid,
       actor: actor1,
       action: 1,
-      object_type: Post,
-      object_id: post1.id
+      namespace: Post,
+      namespace_id: post1.id
     )
 
     Accessly::PermittedActionOnObject.create!(
       id: SecureRandom.uuid,
       actor: actor1,
       action: 1,
-      object_type: Post,
-      object_id: post2.id
+      namespace: Post,
+      namespace_id: post2.id
     )
 
     Accessly::PermittedActionOnObject.create!(
       id: SecureRandom.uuid,
       actor: group1,
       action: 2,
-      object_type: Post,
-      object_id: post3.id
+      namespace: Post,
+      namespace_id: post3.id
     )
 
     Accessly::PermittedActionOnObject.create!(
       id: SecureRandom.uuid,
       actor: group2,
       action: 1,
-      object_type: Post,
-      object_id: post3.id
+      namespace: Post,
+      namespace_id: post3.id
     )
 
     Accessly::Query.new(actor2).list(1, Post).must_equal []
@@ -74,8 +74,8 @@ describe Accessly do
       segment_id: 1,
       actor: actor1,
       action: 1,
-      object_type: Post,
-      object_id: post1.id
+      namespace: Post,
+      namespace_id: post1.id
     )
 
     Accessly::PermittedActionOnObject.create!(
@@ -83,8 +83,8 @@ describe Accessly do
       segment_id: 1,
       actor: actor1,
       action: 1,
-      object_type: Post,
-      object_id: post2.id
+      namespace: Post,
+      namespace_id: post2.id
     )
 
     Accessly::PermittedActionOnObject.create!(
@@ -92,8 +92,8 @@ describe Accessly do
       segment_id: 1,
       actor: group1,
       action: 2,
-      object_type: Post,
-      object_id: post3.id
+      namespace: Post,
+      namespace_id: post3.id
     )
 
     Accessly::PermittedActionOnObject.create!(
@@ -101,8 +101,8 @@ describe Accessly do
       segment_id: 1,
       actor: group2,
       action: 1,
-      object_type: Post,
-      object_id: post3.id
+      namespace: Post,
+      namespace_id: post3.id
     )
 
     Accessly::Query.new(actor2).on_segment(1).list(1, Post).must_equal []

--- a/test/permitted_general_action_test.rb
+++ b/test/permitted_general_action_test.rb
@@ -14,7 +14,7 @@ describe Accessly do
       id: SecureRandom.uuid,
       actor: actor,
       action: 1,
-      object_type: Post
+      namespace: Post
     )
 
     Accessly::Query.new(actor).can?(1, Post).must_equal true

--- a/test/permittted_records_test.rb
+++ b/test/permittted_records_test.rb
@@ -16,8 +16,8 @@ describe Accessly do
       id: SecureRandom.uuid,
       actor: actor,
       action: 1,
-      object_type: Post,
-      object_id: post.id
+      namespace: Post,
+      namespace_id: post.id
     )
 
     Accessly::Query.new(actor).can?(1, Post, post.id).must_equal true
@@ -32,8 +32,8 @@ describe Accessly do
       id: SecureRandom.uuid,
       actor: actor,
       action: 1,
-      object_type: Post,
-      object_id: post.id
+      namespace: Post,
+      namespace_id: post.id
     )
 
     Accessly::PermittedActionOnObject.create!(
@@ -41,8 +41,8 @@ describe Accessly do
       segment_id: 1,
       actor: group,
       action: 2,
-      object_type: Post,
-      object_id: post.id
+      namespace: Post,
+      namespace_id: post.id
     )
 
     Accessly::Query.new(actor).can?([2,1], Post, post.id).must_equal true
@@ -74,24 +74,24 @@ describe Accessly do
       id: SecureRandom.uuid,
       actor: actor1,
       action: 1,
-      object_type: Post,
-      object_id: post.id
+      namespace: Post,
+      namespace_id: post.id
     )
 
     Accessly::PermittedActionOnObject.create!(
       id: SecureRandom.uuid,
       actor: actor3,
       action: 1,
-      object_type: Post,
-      object_id: post.id
+      namespace: Post,
+      namespace_id: post.id
     )
 
     Accessly::PermittedActionOnObject.create!(
       id: SecureRandom.uuid,
       actor: group1,
       action: 2,
-      object_type: Post,
-      object_id: post.id
+      namespace: Post,
+      namespace_id: post.id
     )
 
     Accessly::PermittedActionOnObject.create!(
@@ -99,8 +99,8 @@ describe Accessly do
       segment_id: 1,
       actor: group1,
       action: 5,
-      object_type: Post,
-      object_id: post.id
+      namespace: Post,
+      namespace_id: post.id
     )
 
     Accessly::Query.new(User => actor1.id).can?([2,1], Post, post.id).must_equal true

--- a/test/revoke_general_action_test.rb
+++ b/test/revoke_general_action_test.rb
@@ -4,7 +4,7 @@ describe Accessly do
 
   it "returns nil after a successful revoke" do
     actor = User.create!
-    Accessly::PermittedAction.create!(id: SecureRandom.uuid, actor: actor, action: 1, object_type: "Post")
+    Accessly::PermittedAction.create!(id: SecureRandom.uuid, actor: actor, action: 1, namespace: "Post")
     Accessly::PermittedAction.where(actor: actor).count.must_equal 1
 
     Accessly::Permission::Revoke.new(actor).revoke!(1, Post).must_be_nil
@@ -13,7 +13,7 @@ describe Accessly do
 
   it "returns nil after a successful revoke on a segment" do
     actor = User.create!
-    Accessly::PermittedAction.create!(id: SecureRandom.uuid, segment_id: 1, actor: actor, action: 1, object_type: "Post")
+    Accessly::PermittedAction.create!(id: SecureRandom.uuid, segment_id: 1, actor: actor, action: 1, namespace: "Post")
     Accessly::PermittedAction.where(actor: actor, segment_id: 1).count.must_equal 1
 
     Accessly::Permission::Revoke.new(actor).on_segment(1).revoke!(1, Post).must_be_nil

--- a/test/revoke_records_test.rb
+++ b/test/revoke_records_test.rb
@@ -6,7 +6,7 @@ describe Accessly do
     actor = User.create!
     post = Post.create!
 
-    Accessly::PermittedActionOnObject.create!(id: SecureRandom.uuid, actor: actor, action: 1, object_type: Post, object_id: post.id)
+    Accessly::PermittedActionOnObject.create!(id: SecureRandom.uuid, actor: actor, action: 1, namespace: Post, namespace_id: post.id)
     Accessly::PermittedActionOnObject.where(actor: actor).count.must_equal 1
 
     Accessly::Permission::Revoke.new(actor).revoke!(1, Post, post.id).must_be_nil
@@ -17,7 +17,7 @@ describe Accessly do
     actor = User.create!
     post = Post.create!
 
-    Accessly::PermittedActionOnObject.create!(id: SecureRandom.uuid, segment_id: 1, actor: actor, action: 1, object_type: Post, object_id: post.id)
+    Accessly::PermittedActionOnObject.create!(id: SecureRandom.uuid, segment_id: 1, actor: actor, action: 1, namespace: Post, namespace_id: post.id)
     Accessly::PermittedActionOnObject.where(actor: actor, segment_id: 1).count.must_equal 1
 
     Accessly::Permission::Revoke.new(actor).on_segment(1).revoke!(1, Post, post.id).must_be_nil

--- a/test/schema.rb
+++ b/test/schema.rb
@@ -13,7 +13,7 @@ ActiveRecord::Schema.define(version: 1) do
     t.column :action, :integer, null: false
     t.column :actor_id, :integer, null: false
     t.column :actor_type, :string, null: false
-    t.column :object_type, :string, null: false
+    t.column :namespace, :string, null: false
   end
 
   create_table :accessly_permitted_action_on_objects, force: true, id: :uuid do |t|
@@ -21,12 +21,12 @@ ActiveRecord::Schema.define(version: 1) do
     t.column :action, :integer, null: false
     t.column :actor_id, :integer, null: false
     t.column :actor_type, :string, null: false
-    t.column :object_type, :string, null: false
-    t.column :object_id, :integer, null: false
+    t.column :namespace, :string, null: false
+    t.column :namespace_id, :integer, null: false
   end
 
-  add_index(:accessly_permitted_action_on_objects, [:segment_id, :actor_type, :actor_id, :object_type, :object_id, :action], unique: true, name: "acessly_paoo_uniq_table_idx")
-  add_index(:accessly_permitted_action_on_objects, [:segment_id, :object_type, :object_id, :action], name: "acessly_paoo_on_object_idx")
-  add_index(:accessly_permitted_actions, [:segment_id, :actor_type, :actor_id, :object_type, :action], unique: true, name: "acessly_pa_uniq_table_idx")
+  add_index(:accessly_permitted_action_on_objects, [:segment_id, :actor_type, :actor_id, :namespace, :namespace_id, :action], unique: true, name: "acessly_paoo_uniq_table_idx")
+  add_index(:accessly_permitted_action_on_objects, [:segment_id, :namespace, :namespace_id, :action], name: "acessly_paoo_namespace_idx")
+  add_index(:accessly_permitted_actions, [:segment_id, :actor_type, :actor_id, :namespace, :action], unique: true, name: "acessly_pa_uniq_table_idx")
 
 end


### PR DESCRIPTION
Resolves[[ch9537]](https://app.clubhouse.io/lessonly/story/9537/rename-all-references-of-object-type-namespace)

depends on #12 