### PR TITLE
LCM-1051-change-logic-for-initializing-grant-object

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        ruby: ["2.7", "3.0", "3.1", "3.2"]
+        ruby: ["2.6", "2.7", "3.0"]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        ruby: ["2.6", "2.7", "3.0"]
+        ruby: ["2.7", "3.0", "3.1", "3.2"]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3

--- a/accessly.gemspec
+++ b/accessly.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 2.1"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "minitest", "~> 5.0"
-  spec.add_development_dependency "database_cleaner", "~> 1.8"
+  spec.add_development_dependency "database_cleaner", "~> 2.0"
   spec.add_development_dependency "pg", "~> 1.0"
   spec.add_development_dependency "rails", ">= 5.0"
 end

--- a/lib/accessly/permission/grant.rb
+++ b/lib/accessly/permission/grant.rb
@@ -8,9 +8,9 @@ module Accessly
       # @param actor [ActiveRecord::Base] The actor to grant permission
       def initialize(actor)
         super(actor)
-        @actor = case actor
-        when ActiveRecord::Base
-          actor
+
+        if actor.is_a?(ActiveRecord::Base)
+          @actor = actor
         else
           raise Accessly::GrantError.new("Actor is not an ActiveRecord::Base object")
         end


### PR DESCRIPTION
## Why?

Resolves [LCM-1051](https://seismic.atlassian.net/browse/LCM-1051)

In Rails 7.1 they removed an override of the `===` operator (specifically, [this](https://github.com/rails/rails/blob/v7.0.8.7/activerecord/lib/active_record/core.rb#L414) was removed [in 7.1](https://github.com/rails/rails/blob/v7.1.5.2/activerecord/lib/active_record/core.rb)). This ultimately affects the way `case` statements work.

Now that we have introduced `SeismicUser` and `SeismicGroup` in the core app, the case statement is failing. Explicitly using the `is_a?` method not only makes this more clear, but also preserves the original logic.

## What?

Changes the `case` statement (which implicitly relies on `===`) to an `if`/`else` that uses the `is_a?` method.

## Further Reading

- We're waiting to hear if there's any other guidance around this: https://github.com/rails/rails/issues/55870

## Merge Instructions

Please **DO** squash my commits when merging


[LCM-1051]: https://seismic.atlassian.net/browse/LCM-1051?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ